### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -8,7 +8,7 @@ var _ldclientJs = require('ldclient-js');
 
 var _ldclientJs2 = _interopRequireDefault(_ldclientJs);
 
-var _nodeUuid = require('node-uuid');
+var _nodeUuid = require('uuid');
 
 var _nodeUuid2 = _interopRequireDefault(_nodeUuid);
 

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "keymirror": "^0.1.1",
     "ldclient-js": "^1.1.2",
     "lodash": "^4.16.3",
-    "node-uuid": "^1.4.7",
     "react": "^15.3.2",
-    "ua-parser-js": "^0.7.10"
+    "ua-parser-js": "^0.7.10",
+    "uuid": "^3.0.0"
   }
 }

--- a/src/init.js
+++ b/src/init.js
@@ -1,5 +1,5 @@
 import ldClient from 'ldclient-js';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import ip from 'ip';
 import UAParser from 'ua-parser-js';
 import {setLDReady} from './actions';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.