### PR TITLE
Don't wrap WrappedComponent in a div

### DIFF
--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -94,11 +94,7 @@ exports.default = function (flags) {
       }, {
         key: 'render',
         value: function render() {
-          return _react2.default.createElement(
-            'div',
-            null,
-            _react2.default.createElement(WrappedComponent, this.props)
-          );
+          return _react2.default.createElement(WrappedComponent, this.props);
         }
       }]);
       return WithFeatureFlags;

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -51,13 +51,7 @@ export default flags => (WrappedComponent) => {
     }
 
     render() {
-      return (
-        <div>
-          <WrappedComponent
-            {...this.props}
-          />
-        </div>
-      );
+      return <WrappedComponent {...this.props} />;
     }
   }
 


### PR DESCRIPTION
I’m assuming that there isn’t a reason for the div wrapping `WrappedComponent`.

Having extra divs can present styling pains, thus this PR. 😄 