### PR TITLE
Use prop-types lib to fix deprecations warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ld-redux
 
-[![npm version](https://img.shields.io/npm/v/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux) [![npm downloads](https://img.shields.io/npm/dm/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux) [![npm](https://img.shields.io/npm/dt/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux) [![npm](https://img.shields.io/npm/l/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux) 
+[![npm version](https://img.shields.io/npm/v/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux) [![npm downloads](https://img.shields.io/npm/dm/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux) [![npm](https://img.shields.io/npm/dt/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux) [![npm](https://img.shields.io/npm/l/ld-redux.svg?style=flat-square)](https://www.npmjs.com/package/ld-redux)
 
 > **A library to integrate launch darkly with react redux** :clap:
 
-[Launch Darkly](https://launchdarkly.com/faq.html) is a great tool for feature flagging and a/b testing. It has a fully capable [client-side javascript sdk](https://github.com/launchdarkly/js-client), so why this package? 
+[Launch Darkly](https://launchdarkly.com/faq.html) is a great tool for feature flagging and a/b testing. It has a fully capable [client-side javascript sdk](https://github.com/launchdarkly/js-client), so why this package?
 
 If you use react redux and you want to store your feature flags as part of your redux state, this package will do that for you. It does the heavy lifting of:
 
@@ -28,13 +28,13 @@ npm i --save ld-redux
     ```javascript
     import createStore from '<your-project>/store';
     import ldRedux from 'ld-redux';
-    
+
     // standard redux createStore
     const store = createStore();
-    
+
     // Pass redux store to ld-redux so it can store flags in redux state
     ldRedux.init('yourClientSideId', store);
-    
+
     render(
       <Provider store={store}>
         <Router routes={routes} history={browserHistory}/>
@@ -48,8 +48,8 @@ npm i --save ld-redux
     ```javascript
     import { combineReducers } from 'redux';
     import ldRedux from 'ld-redux';
-    import reducers from '<your-project>/reducers'; 
-   
+    import reducers from '<your-project>/reducers';
+
     export default combineReducers({
       ...reducers,
       LD: ldRedux.reducer(), // Note: key must be upper case LD
@@ -57,24 +57,24 @@ npm i --save ld-redux
     ```
 
 3. Subscribe to flags in your redux container:
-    
+
     ```javascript
     import {connect} from 'react-redux';
     import ldRedux, {ldConnect} from 'ld-redux';
     import * as yourActions from '<your-project>/actions/yourActions';
-    
+
     // These must be the keys you set up in launch darkly dashboard (kebab-lower-cased)
     const homeFlags = {'feature-flag-key': false};
-    
+
     const mapStateToProps = (state) => {
       // Use getFlags to access flags from LD state
       const flags = ldRedux.getFlags(state, homeFlags);
-    
+
       return {
         ...flags,
       };
     };
-    
+
     // Use ldConnect to connect your component to the feature flags it needs
     @connect(mapStateToProps, yourActions)
     @ldConnect(homeFlags)
@@ -84,12 +84,12 @@ npm i --save ld-redux
       }
     };
     ```
-    
+
 4. Finally in your component, your feature flags are available from props in camelCase:
 
     ```javascript
     import React, {Component} from 'react';
-    
+
     export default class Home extends Component {
       render() {
         return (
@@ -111,7 +111,7 @@ npm i --save ld-redux
 
 ## API
 ### init(clientSideId, reduxStore, customUser)
-You can initialise the sdk with a custom user by passing it as the third argument to the init method. This must be an object containing 
+You can initialise the sdk with a custom user by passing it as the third argument to the init method. This must be an object containing
 at least a "key" property. If you don't specify a customUser object, ldRedux will create a default one that looks like this:
 
 ```javascript
@@ -134,7 +134,7 @@ as per step 2 above with the key 'LD'. This name is referenced by the getFlags m
 
 
 ### getFlags(reduxState, flags)
-Extract the specified flags from the given redux state, using the given flag values as default. Internally this 
+Extract the specified flags from the given redux state, using the given flag values as default. Internally this
 looks for the LD key in your state tree to retrieve flags from. The flags argument must be an object like this:
 
 ```javascript
@@ -144,7 +144,7 @@ const flags = {
 };
 
 ```
-The keys in this object must be the same as the one you set up in launch darkly dashboard. They will be 
+The keys in this object must be the same as the one you set up in launch darkly dashboard. They will be
 kebab-lower-cased. The values will be used as default values for the flags.
 
 
@@ -155,18 +155,18 @@ will be able to consume them. The flags object is the same as the one you used i
 It also subscribes your component to feature flag changes (implemented via sse) so it can react (no pun intended)
 automatically to changes without browser refresh.
 
-For more info on subscribing to flag changes, see [here](http://docs.launchdarkly.com/docs/js-sdk-reference#section-subscribing-to-feature-flag-changes). 
+For more info on subscribing to flag changes, see [here](http://docs.launchdarkly.com/docs/js-sdk-reference#section-subscribing-to-feature-flag-changes).
 
 
 ### isLDReady reducer state
-This is a boolean flag in LD reducer which gets set to true when the sdk has finished loading. You can subscribe to this state if you 
+This is a boolean flag in LD reducer which gets set to true when the sdk has finished loading. You can subscribe to this state if you
 need to perform custom operations on component load. By default, the ldRedux.getFlags method injects this flag implicitly so if you follow
 step 3 above, you'll find that isLDReady is already available as props in your component.
 
 
 ### window.ldClient
-Internally the ldRedux.init method above initialises the js sdk and stores the resultant ldClient object in window.ldClient. You can use 
-this object to access the [official sdk methods](https://github.com/launchdarkly/js-client) directly. For example, you can do things like: 
+Internally the ldRedux.init method above initialises the js sdk and stores the resultant ldClient object in window.ldClient. You can use
+this object to access the [official sdk methods](https://github.com/launchdarkly/js-client) directly. For example, you can do things like:
 
 ```javascript
 // track goals
@@ -180,4 +180,4 @@ For more info on changing user context, see the [official documentation](http://
 
 
 ## Example
-Check the [example](https://github.com/yusinto/ld-redux/tree/master/example) for a fully working spa with react, redux and react-router. 
+Check the [example](https://github.com/yusinto/ld-redux/tree/master/example) for a fully working spa with react, redux and react-router.

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -1,16 +1,16 @@
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
-    define(['exports', 'babel-runtime/core-js/object/get-prototype-of', 'babel-runtime/helpers/classCallCheck', 'babel-runtime/helpers/createClass', 'babel-runtime/helpers/possibleConstructorReturn', 'babel-runtime/helpers/inherits', 'react', 'lodash/camelCase', './actions'], factory);
+    define(['exports', 'babel-runtime/core-js/object/get-prototype-of', 'babel-runtime/helpers/classCallCheck', 'babel-runtime/helpers/createClass', 'babel-runtime/helpers/possibleConstructorReturn', 'babel-runtime/helpers/inherits', 'react', 'prop-types', 'lodash/camelCase', './actions'], factory);
   } else if (typeof exports !== "undefined") {
-    factory(exports, require('babel-runtime/core-js/object/get-prototype-of'), require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('babel-runtime/helpers/possibleConstructorReturn'), require('babel-runtime/helpers/inherits'), require('react'), require('lodash/camelCase'), require('./actions'));
+    factory(exports, require('babel-runtime/core-js/object/get-prototype-of'), require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('babel-runtime/helpers/possibleConstructorReturn'), require('babel-runtime/helpers/inherits'), require('react'), require('prop-types'), require('lodash/camelCase'), require('./actions'));
   } else {
     var mod = {
       exports: {}
     };
-    factory(mod.exports, global.getPrototypeOf, global.classCallCheck, global.createClass, global.possibleConstructorReturn, global.inherits, global.react, global.camelCase, global.actions);
+    factory(mod.exports, global.getPrototypeOf, global.classCallCheck, global.createClass, global.possibleConstructorReturn, global.inherits, global.react, global.propTypes, global.camelCase, global.actions);
     global.decorator = mod.exports;
   }
-})(this, function (exports, _getPrototypeOf, _classCallCheck2, _createClass2, _possibleConstructorReturn2, _inherits2, _react, _camelCase, _actions) {
+})(this, function (exports, _getPrototypeOf, _classCallCheck2, _createClass2, _possibleConstructorReturn2, _inherits2, _react, _propTypes, _camelCase, _actions) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
@@ -28,6 +28,8 @@
   var _inherits3 = _interopRequireDefault(_inherits2);
 
   var _react2 = _interopRequireDefault(_react);
+
+  var _propTypes2 = _interopRequireDefault(_propTypes);
 
   var _camelCase2 = _interopRequireDefault(_camelCase);
 
@@ -102,10 +104,10 @@
       }(_react.Component);
 
       WithFeatureFlags.contextTypes = {
-        store: _react.PropTypes.object.isRequired
+        store: _propTypes.object.isRequired
       };
       WithFeatureFlags.propTypes = {
-        isLDReady: _react.PropTypes.bool
+        isLDReady: _propTypes.bool
       };
 
 

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -104,10 +104,10 @@
       }(_react.Component);
 
       WithFeatureFlags.contextTypes = {
-        store: _propTypes.object.isRequired
+        store: _propTypes2.default.object.isRequired
       };
       WithFeatureFlags.propTypes = {
-        isLDReady: _propTypes.bool
+        isLDReady: _propTypes2.default.bool
       };
 
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "keymirror": "^0.1.1",
     "ldclient-js": "^1.1.2",
     "lodash": "^4.16.3",
+    "prop-types": "^15.5.10",
     "ua-parser-js": "^0.7.10",
     "uuid": "^3.0.1"
   },

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react'; // eslint-disable-line import/no-unresolved, import/extensions
+import React, {Component} from 'react'; // eslint-disable-line import/no-unresolved, import/extensions
+import PropTypes from 'prop-types';
 import camelCase from 'lodash/camelCase';
 import {setFlags} from './actions';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,6 +128,10 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+asap@~2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -1033,6 +1037,10 @@ convert-source-map@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.3.0.tgz#e9f3e9c6e2728efc2676696a70eb382f73106a67"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -1148,6 +1156,12 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
 
 es-abstract@^1.7.0:
   version "1.7.0"
@@ -1429,6 +1443,18 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -1696,7 +1722,7 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
@@ -1878,6 +1904,10 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
@@ -1895,6 +1925,13 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2080,7 +2117,7 @@ lodash@^4.0.0, lodash@^4.15.0, lodash@^4.16.3, lodash@^4.17.2, lodash@^4.2.0, lo
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2177,6 +2214,13 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+node-fetch@^1.0.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-pre-gyp@^0.6.29:
   version "0.6.33"
@@ -2357,6 +2401,19 @@ process-nextick-args@~1.0.6:
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+
+promise@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 proxyquire@^1.7.10:
   version "1.7.11"
@@ -2577,6 +2634,10 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
 shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
@@ -2792,7 +2853,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-ua-parser-js@^0.7.10:
+ua-parser-js@^0.7.10, ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
@@ -2843,6 +2904,10 @@ whatwg-encoding@^1.0.1:
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
   dependencies:
     iconv-lite "0.4.13"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whatwg-url@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Accessing PropTypes directly from React is not deprecated and will be
removed entirely from React 16. Currently, we get the following warning

```sh
console.error node_modules/fbjs/lib/warning.js:36
      Warning: Accessing PropTypes via the main React package is
      deprecated. Use the prop-types package from npm instead.
```

This commit adds `prop-types` as dependency and use it as advised.