### PR TITLE
Added the ability to pass `options` to LDClient.initialize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ npm i --save ld-redux
     ```
 
 ## API
-### init(clientSideId, reduxStore, customUser)
+### init(clientSideId, reduxStore, customUser, options)
 You can initialise the sdk with a custom user by passing it as the third argument to the init method. This must be an object containing
 at least a "key" property. If you don't specify a customUser object, ldRedux will create a default one that looks like this:
 
@@ -127,6 +127,13 @@ const defaultUser = {
 
 For more info on the user object, see [here](http://docs.launchdarkly.com/docs/js-sdk-reference#section-users).
 
+The final parameter `options` can be used to pass in extra options such as [Bootstrapping](https://github.com/launchdarkly/js-client#bootstrapping). For example:
+
+```javascript
+ldRedux.init('yourClientSideId', store, customUser, {
+  bootstrap: 'localStorage'
+});
+```
 
 ### reducer()
 This is ld-redux's reducer comprising of a single boolean flag isLDReady. You must include this reducer in your app

--- a/lib/init.js
+++ b/lib/init.js
@@ -35,7 +35,7 @@
   var isMobileDevice = typeof window !== 'undefined' && userAgentParser.getDevice().type === 'mobile';
   var isTabletDevice = typeof window !== 'undefined' && userAgentParser.getDevice().type === 'tablet';
 
-  exports.default = function (clientSideId, reduxStore, user) {
+  exports.default = function (clientSideId, reduxStore, user, options) {
     if (!user) {
       var device = void 0;
 
@@ -57,7 +57,7 @@
       };
     }
 
-    window.ldClient = _ldclientJs2.default.initialize(clientSideId, user);
+    window.ldClient = _ldclientJs2.default.initialize(clientSideId, user, options);
     window.ldClient.on('ready', function () {
       reduxStore.dispatch((0, _actions.setLDReady)());
     });

--- a/src/init.js
+++ b/src/init.js
@@ -8,7 +8,7 @@ const userAgentParser = new UAParser();
 const isMobileDevice = typeof window !== 'undefined' && userAgentParser.getDevice().type === 'mobile';
 const isTabletDevice = typeof window !== 'undefined' && userAgentParser.getDevice().type === 'tablet';
 
-export default (clientSideId, reduxStore, user) => {
+export default (clientSideId, reduxStore, user, options) => {
   if (!user) {
     let device;
 
@@ -30,7 +30,7 @@ export default (clientSideId, reduxStore, user) => {
     };
   }
 
-  window.ldClient = ldClient.initialize(clientSideId, user);
+  window.ldClient = ldClient.initialize(clientSideId, user, options);
   window.ldClient.on('ready', () => {
     reduxStore.dispatch(setLDReady());
   });

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -12,7 +12,7 @@ describe('initialize', () => {
     mock.initialize = td.function('ldClient.initialize');
     mock.onReadyHandler;
 
-    td.when(mock.initialize(MOCK_CLIENT_SIDE_ID, td.matchers.anything())).thenReturn({on: mock.on});
+    td.when(mock.initialize(MOCK_CLIENT_SIDE_ID, td.matchers.anything(), td.matchers.anything())).thenReturn({on: mock.on});
     td.when(mock.on('ready', td.matchers.isA(Function))).thenDo((s, f) => mock.onReadyHandler = f);
 
     mock.ldClient = {
@@ -36,7 +36,7 @@ describe('initialize', () => {
       return user.key && user.ip && user.custom &&
         user.custom.browser === 'WebKit' &&
         user.custom.device === 'desktop';
-    })));
+    }), td.matchers.anything()));
   });
 
   it('should subscribe to ready event with redux dispatch as callback', () => {
@@ -58,7 +58,21 @@ describe('initialize', () => {
     ldReduxInit(MOCK_CLIENT_SIDE_ID, mock.store, customUser);
 
     // assert
-    td.verify(mock.initialize(MOCK_CLIENT_SIDE_ID, td.matchers.contains(customUser)));
+    td.verify(mock.initialize(MOCK_CLIENT_SIDE_ID, td.matchers.contains(customUser), td.matchers.anything()));
+    td.verify(mock.on('ready', td.matchers.isA(Function)));
+    mock.onReadyHandler();
+    td.verify(mock.store.dispatch(td.matchers.contains({type: "LD_READY"})));
+  });
+
+  it('should pass the options through', () => {
+    // arrange
+    const options = {bootstrap: 'localStorage'};
+
+    // act
+    ldReduxInit(MOCK_CLIENT_SIDE_ID, mock.store, null, options);
+
+    // assert
+    td.verify(mock.initialize(MOCK_CLIENT_SIDE_ID, td.matchers.anything(), td.matchers.contains(options)));
     td.verify(mock.on('ready', td.matchers.isA(Function)));
     mock.onReadyHandler();
     td.verify(mock.store.dispatch(td.matchers.contains({type: "LD_READY"})));


### PR DESCRIPTION
This PR adds the ability to pass `options` to LDClient.initialize() which is necessary if you want to use the [Bootstrapping](https://github.com/launchdarkly/js-client#bootstrapping) facility.