### PR TITLE
Add setDefaults flag to connect/decorator.js

### DIFF
--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -1,21 +1,23 @@
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
-    define(['exports', 'babel-runtime/core-js/object/get-prototype-of', 'babel-runtime/helpers/classCallCheck', 'babel-runtime/helpers/createClass', 'babel-runtime/helpers/possibleConstructorReturn', 'babel-runtime/helpers/inherits', 'react', 'prop-types', 'lodash/camelCase', './actions'], factory);
+    define(['exports', 'babel-runtime/helpers/objectWithoutProperties', 'babel-runtime/core-js/object/get-prototype-of', 'babel-runtime/helpers/classCallCheck', 'babel-runtime/helpers/createClass', 'babel-runtime/helpers/possibleConstructorReturn', 'babel-runtime/helpers/inherits', 'react', 'prop-types', 'lodash/camelCase', './actions'], factory);
   } else if (typeof exports !== "undefined") {
-    factory(exports, require('babel-runtime/core-js/object/get-prototype-of'), require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('babel-runtime/helpers/possibleConstructorReturn'), require('babel-runtime/helpers/inherits'), require('react'), require('prop-types'), require('lodash/camelCase'), require('./actions'));
+    factory(exports, require('babel-runtime/helpers/objectWithoutProperties'), require('babel-runtime/core-js/object/get-prototype-of'), require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('babel-runtime/helpers/possibleConstructorReturn'), require('babel-runtime/helpers/inherits'), require('react'), require('prop-types'), require('lodash/camelCase'), require('./actions'));
   } else {
     var mod = {
       exports: {}
     };
-    factory(mod.exports, global.getPrototypeOf, global.classCallCheck, global.createClass, global.possibleConstructorReturn, global.inherits, global.react, global.propTypes, global.camelCase, global.actions);
+    factory(mod.exports, global.objectWithoutProperties, global.getPrototypeOf, global.classCallCheck, global.createClass, global.possibleConstructorReturn, global.inherits, global.react, global.propTypes, global.camelCase, global.actions);
     global.decorator = mod.exports;
   }
-})(this, function (exports, _getPrototypeOf, _classCallCheck2, _createClass2, _possibleConstructorReturn2, _inherits2, _react, _propTypes, _camelCase, _actions) {
+})(this, function (exports, _objectWithoutProperties2, _getPrototypeOf, _classCallCheck2, _createClass2, _possibleConstructorReturn2, _inherits2, _react, _propTypes, _camelCase, _actions) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
+
+  var _objectWithoutProperties3 = _interopRequireDefault(_objectWithoutProperties2);
 
   var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
 
@@ -40,7 +42,6 @@
   }
 
   exports.default = function (flags) {
-    var setDefaults = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
     return function (WrappedComponent) {
       var WithFeatureFlags = function (_Component) {
         (0, _inherits3.default)(WithFeatureFlags, _Component);
@@ -77,10 +78,22 @@
 
             var flagValues = {};
 
+            var _getState = getState(),
+                LD = _getState.LD;
+
+            var isLDReady = LD.isLDReady,
+                featureFlags = (0, _objectWithoutProperties3.default)(LD, ['isLDReady']);
+
+            // If the flags have been retrieved on the server side, then we don't need
+            // to re-retrieve them on the client side. If we do, the flag settings
+            // would be overridden with the defaults set on the client.
+
+            var isFeatureFlagsRetrieved = Object(featureFlags).entries.length > 0;
+
             var _loop = function _loop(flag) {
               var camelCasedKey = (0, _camelCase2.default)(flag);
 
-              if (setDefaults) {
+              if (!isFeatureFlagsRetrieved) {
                 flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
               }
 
@@ -96,7 +109,7 @@
               _loop(flag);
             }
 
-            if (setDefaults) {
+            if (!isFeatureFlagsRetrieved) {
               dispatch((0, _actions.setFlags)(flagValues));
             }
           }

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -92,12 +92,12 @@
             // to re-retrieve them on the client side. If we do, the flag settings
             // would be overridden with the defaults set on the client.
 
-            var isFeatureFlagsRetrieved = (0, _entries2.default)(featureFlags).length > 0;
+            var flagsInitialised = (0, _entries2.default)(featureFlags).length > 0;
 
             var _loop = function _loop(flag) {
               var camelCasedKey = (0, _camelCase2.default)(flag);
 
-              if (!isFeatureFlagsRetrieved) {
+              if (!flagsInitialised) {
                 flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
               }
 
@@ -113,7 +113,7 @@
               _loop(flag);
             }
 
-            if (!isFeatureFlagsRetrieved) {
+            if (!flagsInitialised) {
               dispatch((0, _actions.setFlags)(flagValues));
             }
           }

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -40,6 +40,7 @@
   }
 
   exports.default = function (flags) {
+    var setDefaults = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
     return function (WrappedComponent) {
       var WithFeatureFlags = function (_Component) {
         (0, _inherits3.default)(WithFeatureFlags, _Component);
@@ -78,7 +79,10 @@
 
             var _loop = function _loop(flag) {
               var camelCasedKey = (0, _camelCase2.default)(flag);
-              flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
+
+              if (setDefaults) {
+                flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
+              }
 
               ldClient.on('change:' + flag, function (current) {
                 var newFlagValues = {};
@@ -92,7 +96,9 @@
               _loop(flag);
             }
 
-            dispatch((0, _actions.setFlags)(flagValues));
+            if (setDefaults) {
+              dispatch((0, _actions.setFlags)(flagValues));
+            }
           }
         }, {
           key: 'render',

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -74,7 +74,9 @@
         }, {
           key: 'initialise',
           value: function initialise() {
-            var dispatch = this.context.store.dispatch;
+            var _context$store = this.context.store,
+                dispatch = _context$store.dispatch,
+                getState = _context$store.getState;
 
             var flagValues = {};
 

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -1,21 +1,23 @@
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
-    define(['exports', 'babel-runtime/helpers/objectWithoutProperties', 'babel-runtime/core-js/object/get-prototype-of', 'babel-runtime/helpers/classCallCheck', 'babel-runtime/helpers/createClass', 'babel-runtime/helpers/possibleConstructorReturn', 'babel-runtime/helpers/inherits', 'react', 'prop-types', 'lodash/camelCase', './actions'], factory);
+    define(['exports', 'babel-runtime/core-js/object/entries', 'babel-runtime/helpers/objectWithoutProperties', 'babel-runtime/core-js/object/get-prototype-of', 'babel-runtime/helpers/classCallCheck', 'babel-runtime/helpers/createClass', 'babel-runtime/helpers/possibleConstructorReturn', 'babel-runtime/helpers/inherits', 'react', 'prop-types', 'lodash/camelCase', './actions'], factory);
   } else if (typeof exports !== "undefined") {
-    factory(exports, require('babel-runtime/helpers/objectWithoutProperties'), require('babel-runtime/core-js/object/get-prototype-of'), require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('babel-runtime/helpers/possibleConstructorReturn'), require('babel-runtime/helpers/inherits'), require('react'), require('prop-types'), require('lodash/camelCase'), require('./actions'));
+    factory(exports, require('babel-runtime/core-js/object/entries'), require('babel-runtime/helpers/objectWithoutProperties'), require('babel-runtime/core-js/object/get-prototype-of'), require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('babel-runtime/helpers/possibleConstructorReturn'), require('babel-runtime/helpers/inherits'), require('react'), require('prop-types'), require('lodash/camelCase'), require('./actions'));
   } else {
     var mod = {
       exports: {}
     };
-    factory(mod.exports, global.objectWithoutProperties, global.getPrototypeOf, global.classCallCheck, global.createClass, global.possibleConstructorReturn, global.inherits, global.react, global.propTypes, global.camelCase, global.actions);
+    factory(mod.exports, global.entries, global.objectWithoutProperties, global.getPrototypeOf, global.classCallCheck, global.createClass, global.possibleConstructorReturn, global.inherits, global.react, global.propTypes, global.camelCase, global.actions);
     global.decorator = mod.exports;
   }
-})(this, function (exports, _objectWithoutProperties2, _getPrototypeOf, _classCallCheck2, _createClass2, _possibleConstructorReturn2, _inherits2, _react, _propTypes, _camelCase, _actions) {
+})(this, function (exports, _entries, _objectWithoutProperties2, _getPrototypeOf, _classCallCheck2, _createClass2, _possibleConstructorReturn2, _inherits2, _react, _propTypes, _camelCase, _actions) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
+
+  var _entries2 = _interopRequireDefault(_entries);
 
   var _objectWithoutProperties3 = _interopRequireDefault(_objectWithoutProperties2);
 
@@ -90,7 +92,7 @@
             // to re-retrieve them on the client side. If we do, the flag settings
             // would be overridden with the defaults set on the client.
 
-            var isFeatureFlagsRetrieved = Object(featureFlags).entries.length > 0;
+            var isFeatureFlagsRetrieved = (0, _entries2.default)(featureFlags).length > 0;
 
             var _loop = function _loop(flag) {
               var camelCasedKey = (0, _camelCase2.default)(flag);

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -33,7 +33,7 @@ export default (flags) => (WrappedComponent) => {
     }
 
     initialise() {
-      const {dispatch} = this.context.store;
+      const {dispatch, getState} = this.context.store;
       const flagValues = {};
       const {LD} = getState();
       const {isLDReady, ...featureFlags} = LD;

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -41,12 +41,12 @@ export default (flags) => (WrappedComponent) => {
       // If the flags have been retrieved on the server side, then we don't need
       // to re-retrieve them on the client side. If we do, the flag settings
       // would be overridden with the defaults set on the client.
-      const isFeatureFlagsRetrieved = Object.entries(featureFlags).length > 0;
+      const flagsInitialised = Object.entries(featureFlags).length > 0;
 
       for (const flag in flags) {
         const camelCasedKey = camelCase(flag);
 
-        if (!isFeatureFlagsRetrieved) {
+        if (!flagsInitialised) {
             flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
         }
 
@@ -58,7 +58,7 @@ export default (flags) => (WrappedComponent) => {
         });
       }
 
-      if (!isFeatureFlagsRetrieved) {
+      if (!flagsInitialised) {
           dispatch(setFlags(flagValues));
       }
     }

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import camelCase from 'lodash/camelCase';
 import {setFlags} from './actions';
 
-export default flags => (WrappedComponent) => {
+export default (flags, setDefaults = true) => (WrappedComponent) => {
   class WithFeatureFlags extends Component {
     // Need the store through context to call dispatch
     // https://github.com/reactjs/redux/issues/362
@@ -38,7 +38,10 @@ export default flags => (WrappedComponent) => {
 
       for (const flag in flags) {
         const camelCasedKey = camelCase(flag);
-        flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
+
+        if (setDefaults) {
+            flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
+        }
 
         ldClient.on(`change:${flag}`, (current) => {
           const newFlagValues = {};
@@ -48,7 +51,9 @@ export default flags => (WrappedComponent) => {
         });
       }
 
-      dispatch(setFlags(flagValues));
+      if (setDefaults) {
+          dispatch(setFlags(flagValues));
+      }
     }
 
     render() {

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -41,7 +41,7 @@ export default (flags) => (WrappedComponent) => {
       // If the flags have been retrieved on the server side, then we don't need
       // to re-retrieve them on the client side. If we do, the flag settings
       // would be overridden with the defaults set on the client.
-      const isFeatureFlagsRetrieved = Object(featureFlags).entries.length > 0;
+      const isFeatureFlagsRetrieved = Object.entries(featureFlags).length > 0;
 
       for (const flag in flags) {
         const camelCasedKey = camelCase(flag);


### PR DESCRIPTION
If the featureFlags have already been initialised (say from the server side, and the redux state has been hydrated with these values), we don't want to re-initialise them to the defaults.