### PR TITLE
replace store with dispatch for init method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yarn add ld-redux
     // do this once
     ldRedux.init({
       clientSideId: 'your-client-side-id',
-      store,
+      dispatch: store.dispatch,
       flags,
     });
 
@@ -98,8 +98,8 @@ yarn add ld-redux
     ```
 
 ## API
-### init({clientSideId, store, flags, user, options})
-The init method accepts an object with the above properties. `clientSideId`, `store` and `flags` are mandatory.
+### init({clientSideId, dispatch, flags, user, options})
+The init method accepts an object with the above properties. `clientSideId`, `dispatch` and `flags` are mandatory.
 
 The `user` property is optional. You can initialise the sdk with a custom user by specifying one. This must be an object containing
 at least a "key" property. If you don't specify a user object, ldRedux will create a default one that looks like this:
@@ -123,7 +123,7 @@ For example:
 ```javascript
 ldRedux.init({
     clientSideId,
-    store,
+    dispatch,
     flags,
     options: {
       bootstrap: 'localStorage',

--- a/example/src/client/index.js
+++ b/example/src/client/index.js
@@ -12,7 +12,7 @@ const store = createStore(reduxState);
 
 ldRedux.init({
   clientSideId: 'your-client-side-id',
-  store,
+  dispatch: store.dispatch,
   flags,
 });
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -33,32 +33,32 @@ var isMobileDevice = typeof window !== 'undefined' && userAgentParser.getDevice(
 var isTabletDevice = typeof window !== 'undefined' && userAgentParser.getDevice().type === 'tablet';
 
 // initialise flags with default values in ld redux store
-var initFlags = function initFlags(flags, store) {
+var initFlags = function initFlags(flags, dispatch) {
   var flagValues = { isLDReady: false };
   for (var flag in flags) {
     var camelCasedKey = (0, _camelCase2.default)(flag);
     flagValues[camelCasedKey] = flags[flag];
   }
-  store.dispatch((0, _actions.setFlags)(flagValues));
+  dispatch((0, _actions.setFlags)(flagValues));
 };
 
 // set flags with real values from ld server
-var setFlags = function setFlags(flags, store) {
+var setFlags = function setFlags(flags, dispatch) {
   var flagValues = { isLDReady: true };
   for (var flag in flags) {
     var camelCasedKey = (0, _camelCase2.default)(flag);
     flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
   }
-  store.dispatch((0, _actions.setFlags)(flagValues));
+  dispatch((0, _actions.setFlags)(flagValues));
 };
 
-var subscribeToChanges = function subscribeToChanges(flags, store) {
+var subscribeToChanges = function subscribeToChanges(flags, dispatch) {
   var _loop = function _loop(flag) {
     var camelCasedKey = (0, _camelCase2.default)(flag);
     ldClient.on('change:' + flag, function (current) {
       var newFlagValue = {};
       newFlagValue[camelCasedKey] = current;
-      store.dispatch((0, _actions.setFlags)(newFlagValue));
+      dispatch((0, _actions.setFlags)(newFlagValue));
     });
   };
 
@@ -90,12 +90,12 @@ var initUser = function initUser() {
 
 exports.default = function (_ref) {
   var clientSideId = _ref.clientSideId,
-      store = _ref.store,
+      dispatch = _ref.dispatch,
       flags = _ref.flags,
       user = _ref.user,
       options = _ref.options;
 
-  initFlags(flags, store);
+  initFlags(flags, dispatch);
 
   if (!user) {
     user = initUser();
@@ -103,7 +103,7 @@ exports.default = function (_ref) {
 
   window.ldClient = _ldclientJs2.default.initialize(clientSideId, user, options);
   window.ldClient.on('ready', function () {
-    setFlags(flags, store);
-    subscribeToChanges(flags, store);
+    setFlags(flags, dispatch);
+    subscribeToChanges(flags, dispatch);
   });
 };

--- a/src/init.js
+++ b/src/init.js
@@ -10,32 +10,32 @@ const isMobileDevice = typeof window !== 'undefined' && userAgentParser.getDevic
 const isTabletDevice = typeof window !== 'undefined' && userAgentParser.getDevice().type === 'tablet';
 
 // initialise flags with default values in ld redux store
-const initFlags = (flags, store) => {
+const initFlags = (flags, dispatch) => {
   const flagValues = {isLDReady: false};
   for (const flag in flags) {
     const camelCasedKey = camelCase(flag);
     flagValues[camelCasedKey] = flags[flag];
   }
-  store.dispatch(setFlagsAction(flagValues));
+  dispatch(setFlagsAction(flagValues));
 };
 
 // set flags with real values from ld server
-const setFlags = (flags, store) => {
+const setFlags = (flags, dispatch) => {
   const flagValues = {isLDReady: true};
   for (const flag in flags) {
     const camelCasedKey = camelCase(flag);
     flagValues[camelCasedKey] = ldClient.variation(flag, flags[flag]);
   }
-  store.dispatch(setFlagsAction(flagValues));
+  dispatch(setFlagsAction(flagValues));
 };
 
-const subscribeToChanges = (flags, store) => {
+const subscribeToChanges = (flags, dispatch) => {
   for (const flag in flags) {
     const camelCasedKey = camelCase(flag);
     ldClient.on(`change:${flag}`, (current) => {
       const newFlagValue = {};
       newFlagValue[camelCasedKey] = current;
-      store.dispatch(setFlagsAction(newFlagValue));
+      dispatch(setFlagsAction(newFlagValue));
     });
   }
 };
@@ -61,8 +61,8 @@ const initUser = () => {
   };
 };
 
-export default ({clientSideId, store, flags, user, options}) => {
-  initFlags(flags, store);
+export default ({clientSideId, dispatch, flags, user, options}) => {
+  initFlags(flags, dispatch);
 
   if (!user) {
     user = initUser();
@@ -70,7 +70,7 @@ export default ({clientSideId, store, flags, user, options}) => {
 
   window.ldClient = ldClientPackage.initialize(clientSideId, user, options);
   window.ldClient.on('ready', () => {
-    setFlags(flags, store);
-    subscribeToChanges(flags, store);
+    setFlags(flags, dispatch);
+    subscribeToChanges(flags, dispatch);
   });
 };

--- a/src/init.test.js
+++ b/src/init.test.js
@@ -44,7 +44,7 @@ describe('initialize', () => {
   it('should initFlags with default values and save to redux store', () => {
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
-      store: mock.store,
+      dispatch: mock.store.dispatch,
       flags: {'test-flag': false, 'another-test-flag': true},
     });
 
@@ -66,7 +66,7 @@ describe('initialize', () => {
 
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
-      store: mock.store,
+      dispatch: mock.store.dispatch,
       flags: {'test-flag': false, 'another-test-flag': true},
     });
 
@@ -78,7 +78,7 @@ describe('initialize', () => {
 
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
-      store: mock.store,
+      dispatch: mock.store.dispatch,
       flags: {'test-flag': false, 'another-test-flag': true},
       user,
     });
@@ -90,7 +90,7 @@ describe('initialize', () => {
     const options = {bootstrap: 'localStorage'};
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
-      store: mock.store,
+      dispatch: mock.store.dispatch,
       flags: {'test-flag': false, 'another-test-flag': true},
       options,
     });
@@ -105,7 +105,7 @@ describe('initialize', () => {
 
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
-      store: mock.store,
+      dispatch: mock.store.dispatch,
       flags: {'test-flag': false, 'another-test-flag': true},
     });
 
@@ -131,7 +131,7 @@ describe('initialize', () => {
 
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
-      store: mock.store,
+      dispatch: mock.store.dispatch,
       flags: {'test-flag': false, 'another-test-flag': true},
     });
 


### PR DESCRIPTION
This PR includes a breaking change that replaces `state` in the init method with `dispatch` for increased flexibility on where the init method can be called from. The reason for these changes are discussed here: #18 