### PR TITLE
update ldclient-js version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "ip": "^1.1.3",
-    "ldclient-js": "^1.1.2",
+    "ldclient-js": "^2.1.0",
     "lodash": "^4.16.3",
     "ua-parser-js": "^0.7.10",
     "uuid": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,9 +14,9 @@
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
 
-Base64@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.0.0.tgz#b6b73ee342ce64bf66d6003a4536683bf8a349b5"
+Base64@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.0.1.tgz#def45cc50c961bcc9bf2321d0f52bcbfec1f1bb1"
 
 abab@^1.0.3:
   version "1.0.3"
@@ -2992,11 +2992,11 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-ldclient-js@^1.1.2:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ldclient-js/-/ldclient-js-1.1.8.tgz#2aa21d1836615305f7dc328b6d9b0739c3254ebc"
+ldclient-js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ldclient-js/-/ldclient-js-2.1.0.tgz#963752439580b534c2f434c1062a736c661f7909"
   dependencies:
-    Base64 "1.0.0"
+    Base64 "1.0.1"
     escape-string-regexp "1.0.5"
 
 left-pad@^1.2.0:


### PR DESCRIPTION
Now that https://github.com/launchdarkly/js-client is on v2, manually requiring it in conjunction with ld-redux results in 1.0 dep and 2.0 dep. 

It does not look like the major semver bump has any effect on ld-redux, as most changes are related to analytics changes.