### PR TITLE
Feature/add all flags setting

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -69,6 +69,13 @@ var subscribeToChanges = function subscribeToChanges(flags, dispatch) {
   }
 };
 
+var orderByKey = function orderByKey(flags) {
+  var ordered = {};
+  Object.keys(flags).sort().forEach(function (key) {
+    ordered[key] = flags[key];
+  });
+};
+
 var initUser = function initUser() {
   var device = void 0;
 
@@ -105,10 +112,11 @@ exports.default = function (_ref) {
 
   window.ldClient = _ldclientJs2.default.initialize(clientSideId, user, options);
   window.ldClient.on('ready', function () {
-    if (options.fetchAllFlags) {
+    if (options && options.allFlags) {
       var allFlags = ldClient.allFlags();
       flags = _extends({}, flags, allFlags);
     }
+    flags = orderByKey(flags);
     setFlags(flags, dispatch);
     subscribeToChanges(flags, dispatch);
   });

--- a/lib/init.js
+++ b/lib/init.js
@@ -95,7 +95,8 @@ exports.default = function (_ref) {
       dispatch = _ref.dispatch,
       flags = _ref.flags,
       user = _ref.user,
-      options = _ref.options;
+      options = _ref.options,
+      settings = _ref.settings;
 
   initFlags(flags, dispatch);
 
@@ -105,7 +106,7 @@ exports.default = function (_ref) {
 
   window.ldClient = _ldclientJs2.default.initialize(clientSideId, user, options);
   window.ldClient.on('ready', function () {
-    if (options && options.allFlags) {
+    if (settings && settings.allFlags) {
       var allFlags = ldClient.allFlags();
       flags = _extends({}, flags, allFlags);
     }

--- a/lib/init.js
+++ b/lib/init.js
@@ -69,13 +69,6 @@ var subscribeToChanges = function subscribeToChanges(flags, dispatch) {
   }
 };
 
-var orderByKey = function orderByKey(flags) {
-  var ordered = {};
-  Object.keys(flags).sort().forEach(function (key) {
-    ordered[key] = flags[key];
-  });
-};
-
 var initUser = function initUser() {
   var device = void 0;
 
@@ -116,7 +109,6 @@ exports.default = function (_ref) {
       var allFlags = ldClient.allFlags();
       flags = _extends({}, flags, allFlags);
     }
-    flags = orderByKey(flags);
     setFlags(flags, dispatch);
     subscribeToChanges(flags, dispatch);
   });

--- a/lib/init.js
+++ b/lib/init.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _ldclientJs = require('ldclient-js');
 
 var _ldclientJs2 = _interopRequireDefault(_ldclientJs);
@@ -103,6 +105,10 @@ exports.default = function (_ref) {
 
   window.ldClient = _ldclientJs2.default.initialize(clientSideId, user, options);
   window.ldClient.on('ready', function () {
+    if (options.fetchAllFlags) {
+      var allFlags = ldClient.allFlags();
+      flags = _extends({}, flags, allFlags);
+    }
     setFlags(flags, dispatch);
     subscribeToChanges(flags, dispatch);
   });

--- a/src/init.js
+++ b/src/init.js
@@ -40,6 +40,13 @@ const subscribeToChanges = (flags, dispatch) => {
   }
 };
 
+const orderByKey = (flags) => {
+  const ordered = {};
+  Object.keys(flags).sort().forEach((key) => {
+    ordered[key] = flags[key];
+  });
+};
+
 const initUser = () => {
   let device;
 
@@ -70,10 +77,11 @@ export default ({clientSideId, dispatch, flags, user, options}) => {
 
   window.ldClient = ldClientPackage.initialize(clientSideId, user, options);
   window.ldClient.on('ready', () => {
-    if (options && options.fetchAllFlags) {
+    if (options && options.allFlags) {
       const allFlags = ldClient.allFlags();
       flags = { ...flags, ...allFlags };
-    } 
+    }
+    flags = orderByKey(flags);
     setFlags(flags, dispatch);
     subscribeToChanges(flags, dispatch);
   });

--- a/src/init.js
+++ b/src/init.js
@@ -61,7 +61,7 @@ const initUser = () => {
   };
 };
 
-export default ({clientSideId, dispatch, flags, user, options}) => {
+export default ({clientSideId, dispatch, flags, user, options, settings}) => {
   initFlags(flags, dispatch);
 
   if (!user) {
@@ -70,7 +70,7 @@ export default ({clientSideId, dispatch, flags, user, options}) => {
 
   window.ldClient = ldClientPackage.initialize(clientSideId, user, options);
   window.ldClient.on('ready', () => {
-    if (options && options.allFlags) {
+    if (settings && settings.allFlags) {
       const allFlags = ldClient.allFlags();
       flags = { ...flags, ...allFlags };
     }

--- a/src/init.js
+++ b/src/init.js
@@ -70,6 +70,10 @@ export default ({clientSideId, dispatch, flags, user, options}) => {
 
   window.ldClient = ldClientPackage.initialize(clientSideId, user, options);
   window.ldClient.on('ready', () => {
+    if (options && options.fetchAllFlags) {
+      const allFlags = ldClient.allFlags();
+      flags = { ...flags, ...allFlags };
+    } 
     setFlags(flags, dispatch);
     subscribeToChanges(flags, dispatch);
   });

--- a/src/init.js
+++ b/src/init.js
@@ -40,13 +40,6 @@ const subscribeToChanges = (flags, dispatch) => {
   }
 };
 
-const orderByKey = (flags) => {
-  const ordered = {};
-  Object.keys(flags).sort().forEach((key) => {
-    ordered[key] = flags[key];
-  });
-};
-
 const initUser = () => {
   let device;
 
@@ -81,7 +74,6 @@ export default ({clientSideId, dispatch, flags, user, options}) => {
       const allFlags = ldClient.allFlags();
       flags = { ...flags, ...allFlags };
     }
-    flags = orderByKey(flags);
     setFlags(flags, dispatch);
     subscribeToChanges(flags, dispatch);
   });

--- a/src/init.test.js
+++ b/src/init.test.js
@@ -174,4 +174,24 @@ describe('initialize', () => {
       data: {isLDReady: true, testFlag: true, anotherTestFlag: false, allTestFlag: true},
     })));
   });
+
+  it('should not require flags if allFlags is set', () => {
+    td.when(mock.variation('all-test-flag', true)).thenReturn(true);
+    const options = {allFlags: true};
+    ldReduxInit({
+      clientSideId: MOCK_CLIENT_SIDE_ID,
+      dispatch: mock.store.dispatch,
+      options,
+    });
+
+    mock.onReadyHandler();
+
+    jest.runAllTimers();
+
+    td.verify(mock.store.dispatch(td.matchers.anything()), {times: 2});
+    td.verify(mock.store.dispatch(td.matchers.contains({
+      type: 'SET_FLAGS',
+      data: {isLDReady: true, allTestFlag: true},
+    })));
+  });
 });

--- a/src/init.test.js
+++ b/src/init.test.js
@@ -152,16 +152,16 @@ describe('initialize', () => {
     td.verify(mock.store.dispatch(td.matchers.anything()), {times: 4});
   });
 
-  it('should get all flags with allFlags option set', () => {
+  it('should get all flags with allFlags setting set', () => {
     td.when(mock.variation('test-flag', false)).thenReturn(true);
     td.when(mock.variation('another-test-flag', true)).thenReturn(false);
     td.when(mock.variation('all-test-flag', true)).thenReturn(true);
-    const options = {allFlags: true};
+    const settings = {allFlags: true};
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
       dispatch: mock.store.dispatch,
       flags: {'test-flag': false, 'another-test-flag': true},
-      options,
+      settings,
     });
 
     mock.onReadyHandler();
@@ -175,13 +175,13 @@ describe('initialize', () => {
     })));
   });
 
-  it('should not require flags if allFlags is set', () => {
+  it('should not require flags if allFlags setting is set', () => {
     td.when(mock.variation('all-test-flag', true)).thenReturn(true);
-    const options = {allFlags: true};
+    const settings = {allFlags: true};
     ldReduxInit({
       clientSideId: MOCK_CLIENT_SIDE_ID,
       dispatch: mock.store.dispatch,
-      options,
+      settings,
     });
 
     mock.onReadyHandler();

--- a/src/init.test.js
+++ b/src/init.test.js
@@ -29,12 +29,14 @@ describe('initialize', () => {
     mock.store = td.object(['dispatch']);
     mock.on = td.function('ldClient.on');
     mock.variation = td.function('ldClient.variation');
+    mock.allFlags = td.function('ldClient.allFlags');
 
     td.when(ldClientPackage.initialize(MOCK_CLIENT_SIDE_ID, td.matchers.anything(), td.matchers.anything()))
-      .thenReturn({on: mock.on, variation: mock.variation});
+      .thenReturn({on: mock.on, variation: mock.variation, allFlags: mock.allFlags});
     td.when(mock.on('ready', td.matchers.isA(Function))).thenDo((s, f) => {
       mock.onReadyHandler = f;
     });
+    td.when(mock.allFlags()).thenReturn({'all-test-flag': true});
   });
 
   afterEach(() => {
@@ -148,5 +150,28 @@ describe('initialize', () => {
       data: {anotherTestFlag: false},
     })));
     td.verify(mock.store.dispatch(td.matchers.anything()), {times: 4});
+  });
+
+  it('should get all flags with allFlags option set', () => {
+    td.when(mock.variation('test-flag', false)).thenReturn(true);
+    td.when(mock.variation('another-test-flag', true)).thenReturn(false);
+    td.when(mock.variation('all-test-flag', true)).thenReturn(true);
+    const options = {allFlags: true};
+    ldReduxInit({
+      clientSideId: MOCK_CLIENT_SIDE_ID,
+      dispatch: mock.store.dispatch,
+      flags: {'test-flag': false, 'another-test-flag': true},
+      options,
+    });
+
+    mock.onReadyHandler();
+
+    jest.runAllTimers();
+
+    td.verify(mock.store.dispatch(td.matchers.anything()), {times: 2});
+    td.verify(mock.store.dispatch(td.matchers.contains({
+      type: 'SET_FLAGS',
+      data: {isLDReady: true, testFlag: true, anotherTestFlag: false, allTestFlag: true},
+    })));
   });
 });


### PR DESCRIPTION
**Problem**
We have over 100 feature flags that we use within our app, and it's challenging to maintain a list of default values in the flags object that gets passed to the init method when the majority of them don't need to have a preset and can wait until the LD server returns with actual flag values.

**Solution**
This MR adds the ability to get all flags by setting `allFlags: true` in the new `settings` object param for the init method. i.e.

```javascript
const flags = {'test-one': true, 'test-two': false}
ldRedux.init({
  clientSideId: 'your-client-side-id',
  dispatch: store.dispatch,
  flags,
  settings: {allFlags: true},
});
```



This feature can be used in combination with the flags object, but is no longer necessary if the `allFlags` option is set. An example without flags,

```javascript
ldRedux.init({
  clientSideId: 'your-client-side-id',
  dispatch: store.dispatch,
  settings: {allFlags: true},
});
```