### PR TITLE
Add subscribe argument

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -61,7 +61,7 @@ const initUser = () => {
   };
 };
 
-export default ({clientSideId, dispatch, flags, user, options}) => {
+export default ({clientSideId, dispatch, flags, user, subscribe = true, options}) => {
   initFlags(flags, dispatch);
 
   if (!user) {
@@ -72,6 +72,9 @@ export default ({clientSideId, dispatch, flags, user, options}) => {
   window.ldClient.on('ready', () => {
     const flagsSanitised = flags || ldClient.allFlags();
     setFlags(flagsSanitised, dispatch);
-    subscribeToChanges(flagsSanitised, dispatch);
+
+    if (subscribe) {
+      subscribeToChanges(flagsSanitised, dispatch);
+    }
   });
 };


### PR DESCRIPTION
**Problem**
Sometimes feature is too complicated to show or hide it "on the fly". It may require an app reload. For this case we don't want to lister for the `change` event

**Solution**
Add `subscribe` argument to decide whether subscribe to feature flag changes or not. Default value is `true`
