### PR TITLE
Add config value to turn off camel casing for flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ yarn add ld-redux
     ```
 
 ## API
-### init({clientSideId, dispatch, flags, user, subscribe, options})
+### init({clientSideId, dispatch, flags, useCamelCaseFlagKeys, user, subscribe, options})
 The init method accepts an object with the above properties. `clientSideId`, `dispatch` are mandatory.
 
 The `flags` property is optional. This is an object containing all the flags you want to use and subscribe to in your app.
@@ -132,6 +132,9 @@ const defaultUser = {
 ```
 
 For more info on the user object, see [here](http://docs.launchdarkly.com/docs/js-sdk-reference#section-users).
+
+The `useCamelCaseFlagKeys` property is optional. This defaults to true which means by default the flags that are stored
+in redux will be camel cased. If this property is false, no transformation on the flag name will be done.
 
 The `options` property is optional. It can be used to pass in extra options such as [Bootstrapping](https://github.com/launchdarkly/js-client#bootstrapping).
 For example:

--- a/src/init.test.js
+++ b/src/init.test.js
@@ -222,4 +222,39 @@ describe('initialize', () => {
     td.verify(mock.on('change:test-flag', td.matchers.isA(Function)));
     td.verify(mock.on('change:another-test-flag', td.matchers.isA(Function)));
   });
+
+  it('should not camel case provided flags if specified', () => {
+    td.when(mock.variation('test-flag', false)).thenReturn(true);
+    td.when(mock.variation('another-test-flag', true)).thenReturn(false);
+
+    ldReduxInit({
+      clientSideId: MOCK_CLIENT_SIDE_ID,
+      dispatch: mock.store.dispatch,
+      useCamelCaseFlagKeys: false,
+      flags: { 'test-flag': false, 'another-test-flag': true },
+    });
+
+    td.verify(
+      mock.store.dispatch(
+        td.matchers.contains({
+          type: 'SET_FLAGS',
+          data: { isLDReady: false, 'test-flag': false, 'another-test-flag': true },
+        }),
+      ),
+    );
+
+    mock.onReadyHandler();
+
+    jest.runAllTimers();
+
+    td.verify(mock.store.dispatch(td.matchers.anything()), { times: 2 });
+    td.verify(
+      mock.store.dispatch(
+        td.matchers.contains({
+          type: 'SET_FLAGS',
+          data: { isLDReady: false, 'test-flag': false, 'another-test-flag': true },
+        }),
+      ),
+    );
+  });
 });


### PR DESCRIPTION
# What this does
Adds a new config key of `camelCased` to the `init()` function to optionally turn off camel casing flags.

# What it looks like

## `camelCased: false`
![image](https://user-images.githubusercontent.com/7519543/71040600-d1529b80-20db-11ea-8bd9-248dfd61ce97.png)

## `camelCased: true` or unspecified
![image](https://user-images.githubusercontent.com/7519543/71040670-fcd58600-20db-11ea-8f8d-9fbb6a9112cf.png)


# How I tested this
Adding a unit test