### PR TITLE
[patch] Conditional camelCase in `subscribeToChanges`

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -54,12 +54,12 @@ var setFlags = function setFlags(flags, dispatch, useCamelCaseFlagKeys) {
   dispatch((0, _actions.setFlags)(flagValues));
 };
 
-var subscribeToChanges = function subscribeToChanges(flags, dispatch) {
+var subscribeToChanges = function subscribeToChanges(flags, dispatch, useCamelCaseFlagKeys) {
   var _loop = function _loop(flag) {
-    var camelCasedKey = (0, _lodash2.default)(flag);
+    var flagKey = useCamelCaseFlagKeys ? (0, _lodash2.default)(flag) : flag;
     ldClient.on('change:' + flag, function (current) {
       var newFlagValue = {};
-      newFlagValue[camelCasedKey] = current;
+      newFlagValue[flagKey] = current;
       dispatch((0, _actions.setFlags)(newFlagValue));
     });
   };
@@ -115,7 +115,7 @@ exports.default = function (_ref) {
     setFlags(flagsSanitised, dispatch, useCamelCaseFlagKeys);
 
     if (sanitisedSubscribe) {
-      subscribeToChanges(flagsSanitised, dispatch);
+      subscribeToChanges(flagsSanitised, dispatch, useCamelCaseFlagKeys);
     }
   });
 };

--- a/src/init.js
+++ b/src/init.js
@@ -33,12 +33,12 @@ const setFlags = (flags, dispatch, useCamelCaseFlagKeys) => {
   dispatch(setFlagsAction(flagValues));
 };
 
-const subscribeToChanges = (flags, dispatch) => {
+const subscribeToChanges = (flags, dispatch, useCamelCaseFlagKeys) => {
   for (const flag in flags) {
-    const camelCasedKey = camelCase(flag);
+    const flagKey = useCamelCaseFlagKeys ? camelCase(flag) : flag;
     ldClient.on(`change:${flag}`, current => {
       const newFlagValue = {};
-      newFlagValue[camelCasedKey] = current;
+      newFlagValue[flagKey] = current;
       dispatch(setFlagsAction(newFlagValue));
     });
   }
@@ -81,7 +81,7 @@ export default ({ clientSideId, dispatch, flags, useCamelCaseFlagKeys = true, us
     setFlags(flagsSanitised, dispatch, useCamelCaseFlagKeys);
 
     if (sanitisedSubscribe) {
-      subscribeToChanges(flagsSanitised, dispatch);
+      subscribeToChanges(flagsSanitised, dispatch, useCamelCaseFlagKeys);
     }
   });
 };

--- a/src/init.test.js
+++ b/src/init.test.js
@@ -140,7 +140,7 @@ describe('initialize', () => {
     );
   });
 
-  it('should subscribe to flag changes once ready', () => {
+  it('should subscribe to camelCase flag changes once ready', () => {
     td.when(mock.on('change:test-flag', td.matchers.isA(Function))).thenDo((e, f) => f(true));
     td.when(mock.on('change:another-test-flag', td.matchers.isA(Function))).thenDo((e, f) => f(false));
 
@@ -167,6 +167,40 @@ describe('initialize', () => {
         td.matchers.contains({
           type: 'SET_FLAGS',
           data: { anotherTestFlag: false },
+        }),
+      ),
+    );
+    td.verify(mock.store.dispatch(td.matchers.anything()), { times: 4 });
+  });
+
+  it('should subscribe to kebab-case flag changes once ready', () => {
+    td.when(mock.on('change:test-flag', td.matchers.isA(Function))).thenDo((e, f) => f(true));
+    td.when(mock.on('change:another-test-flag', td.matchers.isA(Function))).thenDo((e, f) => f(false));
+
+    ldReduxInit({
+      clientSideId: MOCK_CLIENT_SIDE_ID,
+      dispatch: mock.store.dispatch,
+      flags: { 'test-flag': false, 'another-test-flag': true },
+      useCamelCaseFlagKeys: false,
+    });
+
+    mock.onReadyHandler();
+
+    jest.runAllTimers();
+
+    td.verify(
+      mock.store.dispatch(
+        td.matchers.contains({
+          type: 'SET_FLAGS',
+          data: { 'test-flag': true },
+        }),
+      ),
+    );
+    td.verify(
+      mock.store.dispatch(
+        td.matchers.contains({
+          type: 'SET_FLAGS',
+          data: { 'another-test-flag': false },
         }),
       ),
     );


### PR DESCRIPTION
## Summary

Checks the user's `useCamelCaseFlagKeys` setting in `subscribeToChanges` and preserves original case when the value is `false`.

Fixes issue #63

## Screenshots

**Before**

Flag key is transformed to camelCase, even though `useCamelCaseFlagKeys` is set to `false`.

<img width="852" alt="camelCase" src="https://user-images.githubusercontent.com/9545215/133506904-242f477f-a134-4c45-ba22-ec9a42560106.png">

**After**

Flag key is not transformed, and original kebab-case is preserved

<img width="923" alt="kebab-case" src="https://user-images.githubusercontent.com/9545215/133506970-7be271ce-7b2c-4813-8d7f-98c05632679d.png">
